### PR TITLE
Mark typed_value::off_data_ and typed_value::val_data_ as signed chars, fixing arm64 build

### DIFF
--- a/include/savvy/typed_value.hpp
+++ b/include/savvy/typed_value.hpp
@@ -1709,8 +1709,8 @@ namespace savvy
 //    char *off_ptr_ = nullptr;
 //    char *val_ptr_ = nullptr;
 //    std::vector<char> local_data_;
-    std::vector<char> off_data_;
-    std::vector<char> val_data_;
+    std::vector<signed char> off_data_;
+    std::vector<signed char> val_data_;
     bool pbwt_flag_ = false;
   };
 


### PR DESCRIPTION
Mark typed_value::off_data a signed char, allowing templates to work on arm64 where char is unsigned.

Without this, savvy & things that depend and it cannot build or run on arm64 because the templates that are supposed to operate on these don't work.